### PR TITLE
docs: change examples `:import` to `@st-import`

### DIFF
--- a/docs/guides/component-best-practices.md
+++ b/docs/guides/component-best-practices.md
@@ -118,10 +118,8 @@ This helps with maintenance and development since we don't test CSS as thoroughl
 Import CSS or Stylable variables from the [project commons stylesheet](../guides/project-commons.md).
 
 ```css
-:import {
-    -st-from: "./project.st.css";
-    -st-named: color1, --font-small;
-}
+@st-import [color1, --font-small] from "./project.st.css";
+
 .item {
     background: value(color1);
     font-size: var(--font-small);

--- a/docs/guides/component-variants.md
+++ b/docs/guides/component-variants.md
@@ -14,10 +14,9 @@ In your project's [Stylable stylesheet](./project-commons.md) used for the commo
 
 ```css
 @namespace "project";
-:import {
-    -st-from: "./button.st.css";
-    -st-default: Button; 
-}
+
+@st-import Button from "./button.st.css";
+
 .cancelButton {
     -st-extend: Button;
     color: red;
@@ -31,10 +30,9 @@ A component **Stylable** stylesheet can use and extend component variants:
 
 ```css
 @namespace "comp";
-:import {
-    -st-from: './project.st.css';
-    -st-named: cancelButton;
-}
+
+@st-import [cancelButton] from "./project.st.css";
+
 /*
 selector: .comp__root .project__cancelButton.button__root
 js value: "project__cancelButton"

--- a/docs/guides/components-basics.md
+++ b/docs/guides/components-basics.md
@@ -105,10 +105,8 @@ Let's also import `Button`'s stylesheet into the `Panel` stylesheet. You can the
 
 ```css
 /* panel.st.css */
-:import {
-    -st-from: './button.st.css';
-    -st-default: Button;
-}
+@st-import Button from "./button.st.css";
+
 .root {}
 
 /* cancelBtn is of type Button */

--- a/docs/guides/project-commons.md
+++ b/docs/guides/project-commons.md
@@ -20,10 +20,8 @@ In the following code, you can see a project with:
     fontSmall: 1rem;
     spacing: 6px;
 }
-:import {
-    -st-from: './button/button.st.css';
-    -st-default: Button;
-}
+@st-import Button from "./button/button.st.css";
+
 .cancelButton {
     -st-extends: Button;
 }

--- a/docs/guides/shared-classes.md
+++ b/docs/guides/shared-classes.md
@@ -22,7 +22,7 @@ In the [commons stylable stylesheet](./project-commons.md) of your project (usua
 A component's **Stylable** stylesheet can use and extend shared classes:
 
 ```css
-@namespace 'comp';
+@namespace "comp";
 @st-import [emphasisBox] from "./project.st.css";
 /*
 selector: .comp__root .project__emphasisBox

--- a/docs/guides/shared-classes.md
+++ b/docs/guides/shared-classes.md
@@ -22,11 +22,8 @@ In the [commons stylable stylesheet](./project-commons.md) of your project (usua
 A component's **Stylable** stylesheet can use and extend shared classes:
 
 ```css
-@namespace "comp";
-:import {
-    -st-from: './project.st.css';
-    -st-named: emphasisBox;
-}
+@namespace 'comp';
+@st-import [emphasisBox] from "./project.st.css";
 /*
 selector: .comp__root .project__emphasisBox
 js value: "project__emphasisBox"

--- a/docs/guides/stylable-application.md
+++ b/docs/guides/stylable-application.md
@@ -26,10 +26,8 @@ An application would define CSS with the final style definitions:
     fontBig: 30px;
     fontSmall: 10px;
 }
-:import {
-    -st-from: './button/button.st.css';
-    -st-default: Button;
-}
+@st-import Button from "./button/button.st.css";
+
 .cancelButton {
     -st-extends: Button;
     color: value(color1);
@@ -47,14 +45,10 @@ In the following code you can see a component that is described with:
 
 ```css
 @namespace "dialog";
-:import {
-    -st-from: './project.st.css';
-    -st-named: color1, color2, cancelButton;
-}
-:import {
-    -st-from: './button/button.st.css';
-    -st-default: Button;
-}
+
+@st-import [color1, color2, cancelButton] from "./project.st.css";
+@st-import Button from "./button/button.st.css";
+
 .root {
     color: value(color1);
     background: value(color2);

--- a/docs/guides/stylable-component-library.md
+++ b/docs/guides/stylable-component-library.md
@@ -67,16 +67,16 @@ Your components should be as easy to style as possible. We recommend following t
 More best practices for themable components can be found in the [**Stylable** component best practices guide](./component-best-practices.md).
 
 In the following code, you can see a component described with:
+
 * 2 colors used from project
 * 1 shared class 
 
 ```css
 /* app.st.css */
 @namespace "App";
-:import {
-    -st-from: '../project.st.css';
-    -st-named: color1, color2, emphasisBox;
-}
+
+@st-import [color1, color2, emphasisBox] from "../project.st.css";
+
 .root {
     color: value(color1);
     background: value(color2);
@@ -87,33 +87,4 @@ In the following code, you can see a component described with:
 }
 ```
 
-## Theme
-
-The **Stylable** library can include multiple theme files that render a different look and feel per theme. A theme imports the `project.st.css` file as a theme base to override variables, variants and classes from the library.
-
-In the following code, you can see a theme file customizing the library:
-* override `color1` and `color2`
-* CSS for `cancelButton` variant component
-* CSS for `emphsisBox` shared class
-
-```css
-/* backoffice-theme.st.css */
-@namespace "backofficeTheme";
-:import {
-    -st-from: '../project.st.css';
-    -st-named: color1, color2, cancelButton, emphasisBox;
-    color1: white;
-    color2: red;
-}
-.cancelButton {
-    color: value(color1);
-    background: value(color2);
-}
-.emphasisBox {
-    border: 3px solid value(color2);
-}
-```
-
 Read more about using themes in [theme an application](./stylable-application#apply-component-library-theme).
-
-

--- a/docs/references/class-selectors.md
+++ b/docs/references/class-selectors.md
@@ -70,10 +70,8 @@ Classes imported this way should be scoped to your local stylesheet by adding `.
 ```css
 /* form.st.css */
 @namespace "Form";
-:import {
-    -st-from: './button.st.css';
-    -st-named: icon, label; 
-}
+
+@st-import [icon, label] from "./button.st.css";
 
 /* @selector .Form__myIcon.Button__icon */
 .myIcon { 

--- a/docs/references/css-vars.md
+++ b/docs/references/css-vars.md
@@ -48,10 +48,7 @@ Due to the fact Stylable provides scoping to CSS variables, it also provides the
 
 ```css
 /* entry.st.css */
-:import {
-    -st-from: "./imported.st.css";
-    -st-named: --myVar;
-}
+@st-import [--myVar] from "./imported.st.css";
 
 .root {
     /* value determined by the nearest property assignment up the DOM tree */

--- a/docs/references/custom-selectors.md
+++ b/docs/references/custom-selectors.md
@@ -33,10 +33,9 @@ Custom selectors generate a [pseudo-element](./pseudo-elements.md). So, for exam
 
 ```css
 @namespace "Page";
-:import {
-    -st-from: "./comp.st.css";
-    -st-default: Comp;
-}
+
+@st-import Comp from "./comp.st.css";
+
 /*
 selector: .Comp__root .Comp__controls .Comp__btn
 */
@@ -72,10 +71,9 @@ Here you can use the icon `custom selector` from the outside just like you would
 
 ```css
 @namespace "Panel";
-:import {
-    -st-from: "./tree.st.css";
-    -st-default: Tree;
-}
+
+@st-import Tree from "./tree.st.css";
+
 /*
 selector: .Tree__root > .Tree__icon
 */
@@ -91,10 +89,8 @@ When you want to make internal parts of your component API more accessible, you 
 For example, you can expose a `pseudo-element` named `navigationBtn` that enables you to style an internal gallery component's `navBtn` element.
 
 ```css
-:import {
-    -st-from: "./gallery.st.css";
-    -st-default: Gallery;
-}
+@st-import Gallery from "./gallery.st.css";
+
 @custom-selector :--navigationBtn Gallery::navBtn;
 ```
 
@@ -111,10 +107,9 @@ For example, a `pseudo-element` named `navBtn` matches any `btn` CSS class neste
 
 ```css
 @namespace "Page";
-:import {
-    -st-from: "./comp.st.css";
-    -st-default: Comp;
-}
+
+@st-import Comp from "./comp.st.css";
+
 /*
 selector: .Comp__root .Comp__nav .Comp__btn
 */
@@ -147,10 +142,9 @@ For example, when you import the `Comp` stylesheet (the selector described in th
 
 ```css
 @namespace "Page";
-:import {
-    -st-from: "./comp.st.css";
-    -st-default: Comp;
-}
+
+@st-import Comp from "./comp.st.css";
+
 Comp::media { 
     border-color: red; 
 }

--- a/docs/references/extend-stylesheet.md
+++ b/docs/references/extend-stylesheet.md
@@ -16,10 +16,9 @@ In this example, the stylesheet is extending the `toggle-button.st.css` styleshe
 ```css
 /* page.st.css */
 @namespace "Page";
-:import {
-    -st-from: "./toggle-button.st.css";
-    -st-default: ToggleButton;
-}
+
+@st-import ToggleButton from "./toggle-button.st.css";
+
 .checkBtn {
     -st-extends: ToggleButton;
     background: white;
@@ -78,14 +77,9 @@ Any class other than `root` defined in a Stylesheet is considered an inner part.
 ```css
 /* page.st.css */
 @namespace "Page";
-:import {
-    -st-from: "./toggle-button.st.css";
-    -st-default: ToggleButton;
-}
-:import {
-    -st-from: "./toggle-button-variant.st.css";
-    -st-named: toggleVariant;
-}
+
+@st-import ToggleButton from "./toggle-button.st.css";
+@st-import [toggleVariant] from "./toggle-button-variant.st.css";
 
 .defaultCheckBtn {
     -st-extends: ToggleButton; /* extending stylesheet */

--- a/docs/references/formatters.md
+++ b/docs/references/formatters.md
@@ -34,10 +34,7 @@ module.exports = function(baseSize, modifier) {
 ```
 
 ```css
-:import {
-    -st-from: "./calc-font-size";
-    -st-default: calcFontSize;
-}
+@st-import calcFontSize from "./calc-font-size.st.css";
 
 .header {
     font-size: calcFontSize(16, header);
@@ -82,10 +79,7 @@ When the formatter is imported into the CSS, it can also be used with a [variabl
 In this example the CSS imports the same formatter as the previous example, `calc-font-size`, but the variable `baseFontSize` is added to the calculation.  
 
 ```css
-:import {
-    -st-from: "./calc-font-size";
-    -st-default: calcFontSize;
-}
+@st-import calcFontSize from "./calc-font-size.st.css";
 
 :vars {
     baseFontSize: 12;
@@ -128,10 +122,7 @@ module.export = {
 ```
 
 ```css
-:import {
-    -st-from: "./math";
-    -st-named: divBy2, round;
-}
+@st-import [divBy2, round] from "./math.st.css";
 
 :vars {
     baseSize: 17px;

--- a/docs/references/formatters.md
+++ b/docs/references/formatters.md
@@ -34,7 +34,7 @@ module.exports = function(baseSize, modifier) {
 ```
 
 ```css
-@st-import calcFontSize from "./calc-font-size.st.css";
+@st-import calcFontSize from "./calc-font-size";
 
 .header {
     font-size: calcFontSize(16, header);
@@ -79,7 +79,7 @@ When the formatter is imported into the CSS, it can also be used with a [variabl
 In this example the CSS imports the same formatter as the previous example, `calc-font-size`, but the variable `baseFontSize` is added to the calculation.  
 
 ```css
-@st-import calcFontSize from "./calc-font-size.st.css";
+@st-import calcFontSize from "./calc-font-size";
 
 :vars {
     baseFontSize: 12;
@@ -122,7 +122,7 @@ module.export = {
 ```
 
 ```css
-@st-import [divBy2, round] from "./math.st.css";
+@st-import [divBy2, round] from "./math";
 
 :vars {
     baseSize: 17px;

--- a/docs/references/imports.md
+++ b/docs/references/imports.md
@@ -15,7 +15,7 @@ title: Imports
 @st-import DefaultComp, [somePart, someVar] from './stylesheet.st.css';
 ```
 
-- `:import` ruleset directive - The original more verbose way of importing symbols, uses the **Stylable** syntax beginning with `-st-` inside the `:import` ruleset:
+- `:import` ruleset directive - The legacy more verbose way of importing symbols, uses the **Stylable** syntax beginning with `-st-` inside the `:import` ruleset:
     * `-st-from:` Identifies the path to the stylesheet or JavaScript module. Can be a relative path or a 3rd party path.
     * `-st-default:` Imports the default export of the module named in `-st-from:`. Use with the name by which to identify the imported value in the scoped stylesheet.
     * `-st-named:` List of the named exports to import into the local scoped stylesheet from the file named in `-st-from:`.
@@ -34,8 +34,9 @@ Every example below will feature both types of import syntaxes, their end result
 
 * `:import` is a Stylable directive and not a selector.
 * likewise, `@st-import` is a Stylable directive and not an actual at-rule.
-* Import statements cannot be used as a part of a complex selector or inside a CSS ruleset.
+* Import statements cannot be nested or be part of a complex selector.
 * Multiple imports may conflict in their used symbol names; the last one in the file wins.
+* When an imported symbol conflicts with a local symbol the local will be used.
 
 :::
 
@@ -60,19 +61,6 @@ Generally when importing a **default** value from a stylable file, you should us
 @st-import ToggleButton from './button.st.css';
 ```
 
-```css
-/* comp.st.css - legacy syntax */
-:import {
-    -st-from: './button.st.css';
-    -st-default: ToggleButton;
-}
-```
-
-```js
-/* ES6 "equivalent" */
-import ToggleButton from './button.st.css';
-```
-
 ### Import named parts from a local stylesheet
 Named imports from a stylesheet can be used to bring symbols of different types, which you can then use inside your stylesheet.
 
@@ -86,19 +74,6 @@ In this
 ```css
 /* comp.st.css - atRule syntax */
 @st-import [label, icon, --bgColor] from './button.st.css';
-```
-
-```css
-/* comp.st.css - legacy syntax */
-:import {
-    -st-from: './button.st.css';
-    -st-named: label, icon, --bgColor;
-}
-```
-
-```js
-/* ES6 "equivalent" */
-import { label, icon, --bgColor } from './button.st.css';
 ```
 
 ### Import named exports from a local JS module
@@ -116,19 +91,6 @@ When importing named values, they are generally used as class or tag selectors a
 @st-import [gridMixin, tooltipMixin] from './my-mixins';
 ```
 
-```css
-/* comp.st.css - legacy syntax */
-:import {
-    -st-from: "./my-mixins";
-    -st-named: gridMixin, tooltipMixin;
-}
-```
-
-```js
-/* ES6 equivalent */
-import { gridMixin, tooltipMixin } from "./my-mixins";
-```
-
 ### Import named exports from a local JS module and locally refer to one of the export values as a different name
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. The value `gridMixin` is used as is and `tooltipMixin` has been renamed for use in this scoped stylesheet as `tooltip`. These mixins are referred to as `gridMixin` and `tooltip` in this stylesheet.
@@ -136,19 +98,6 @@ The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript
 ```css
 /* comp.st.css - atRule syntax */
 @st-import [gridMixin, tooltipMixin as tooltip] from './my-mixins';
-```
-
-```css
-/* comp.st.css - legacy syntax */
-:import {
-    -st-from: "./my-mixins";
-    -st-named: gridMixin, tooltipMixin as tooltip;
-}
-```
-
-```js
-/* ES6 equivalent */
-import { gridMixin, tooltipMixin as tooltip } from "./my-mixins";
 ```
 
 ## Import keyframes
@@ -162,16 +111,7 @@ Due to this, when importing keyframes from another stylesheet, a special `keyfra
 @st-import [keyframes(slideX, slideY)] from './keyframes.st.css';
 ```
 
-```css
-/* comp.st.css - legacy syntax */
-:import {
-    -st-from: "./my-mixins";
-    -st-named: keyframes(slideX, slideY);
-}
-```
-
 You can read more about keyframes behavior [here](./keyframes.md).
-
 
 ## Importing specific symbols
 

--- a/docs/references/keyframes.md
+++ b/docs/references/keyframes.md
@@ -47,10 +47,7 @@ To import any such symbol in a different stylesheet, **Stylable** uses a utility
 ```css
 /* index.st.css */
 
-:import {
-    -st-from: "./animations.st.css";
-    -st-named: keyframes(slideX, slideY);
-}
+@st-import [keyframes(slideX, slideY)] from "./animations.st.css";
 
 .root { animation-name: slideX; }
 
@@ -76,11 +73,7 @@ To import any such symbol in a different stylesheet, **Stylable** uses a utility
 To create a local alias of a keyframe, Stylable supports the same `[NAME] as [NEW_NAME]` syntax inside the keyframe import utility, as it does for any named import.
 
 ```css
-:import {
-    -st-from: "./animations.st.css";
-    -st-named: keyframes(slide as mySlide),
-               somePart as myPart;
-}
+@st-import [keyframes(slide as mySlide)] from "./animations.st.css";
 ```
 
 Note that this keyframe will be re-exported under its new alias name, and not the original imported name.

--- a/docs/references/mixins.md
+++ b/docs/references/mixins.md
@@ -56,13 +56,9 @@ Here is an example of a **Stylable** CSS file that is imported and mixed into th
 }
 ```
 
-``` css
+```css
 /* example.st.css - imports the above mixin */
-:import {
-    -st-from: './mixins.st.css';
-    -st-default: MixRoot;
-    -st-named: someClass;
-}
+@st-import MixRoot, [someClass] from "./mixins.st.css";
 
 .rootMixedIn {
     -st-mixin: MixRoot; /* stylesheet mixin */
@@ -105,7 +101,7 @@ mixin (
 )
 ```
  
- Using parameters in a mixin enables you to override specific [variables](./variables.md) inside of a mixin before they are applied.
+Using parameters in a mixin enables you to override specific [variables](./variables.md) inside of a mixin before they are applied.
 
 Here is an example of using a variable in a CSS mixin and how it can be overridden by the mixin's parameter value.
 
@@ -223,12 +219,9 @@ module.exports = function colorAndBg([color, bgColor]){
 };
 ```
 
-``` css
+```css
 /* file example.st.css */
-:import {
-    -st-from: './my-mixin';
-    -st-default: colorAndBg;
-}
+@st-import colorAndBg from "./my-mixin";
 
 .codeMixedIn {
     -st-mixin: colorAndBg(green, orange); 
@@ -269,12 +262,9 @@ module.exports = function complexMixin([color, bgColor]){
 };
 ```
 
-``` css
+```css
 /* file example.st.css */
-:import {
-    -st-from: './my-mixin';
-    -st-default: complexMixin;
-}
+@st-import complexMixin from "./my-mixin";
 
 .codeMixedIn {
     -st-mixin: complexMixin(green, orange); 

--- a/docs/references/pseudo-classes.md
+++ b/docs/references/pseudo-classes.md
@@ -90,10 +90,7 @@ You can extend another imported stylesheet and inherit its custom pseudo-classes
 ```css
 /* example2.st.css */
 @namespace "Example2";
-:import {
-    -st-from: "./example1.st.css";
-    -st-default: Comp1;
-}
+@st-import Comp1 from "./example1.st.css";
 .mediaButton {
     -st-extends: Comp1;
     -st-states: toggled, selected;

--- a/docs/references/pseudo-elements.md
+++ b/docs/references/pseudo-elements.md
@@ -30,10 +30,7 @@ In this example, you [import](./imports.md) a `VideoPlayer` component into your 
 
 ```css
 @namespace "Page";
-:import {
-    -st-from: './video-player.st.css';
-    -st-default: VideoPlayer;
-}
+@st-import VideoPlayer from "./video-player.st.css";
 .mainVideo {
     -st-extends: VideoPlayer; /* define mainVideo as VideoPlayer */
 }
@@ -69,10 +66,7 @@ The `page.css` stylesheet can then extend `super-video-player.css` and on the `.
 ```css
 /* super-video-player.st.css */
 @namespace "SuperVideoPlayer";
-:import {
-    -st-from: './video-player.st.css';
-    -st-default: VideoPlayer;
-}
+@st-import VideoPlayer from "./video-player.st.css";
 .root {
     -st-extends: VideoPlayer;
 }
@@ -92,10 +86,7 @@ The `page.css` stylesheet can then extend `super-video-player.css` and on the `.
 ```css
 /* page.st.css */
 @namespace "Page";
-:import {
-    -st-from: './super-video-player.st.css';
-    -st-default: SuperVideoPlayer;
-}
+@st-import SuperVideoPlayer from "./super-video-player.st.css";
 .mainPlayer {
     -st-extends: SuperVideoPlayer;
 }
@@ -127,10 +118,7 @@ In this example, `root` extends `VideoPlayer` and so any class placed on the `ro
 
 ```css
 @namespace "SuperVideoPlayer";
-:import {
-    -st-from: './video-player.st.css';
-    -st-default: VideoPlayer;
-}
+@st-import VideoPlayer from "./video-player.st.css";
 .root {
     -st-extends: VideoPlayer;
 }

--- a/docs/references/st-scope.md
+++ b/docs/references/st-scope.md
@@ -36,11 +36,7 @@ In this theme implementation we are targeting three components and overriding th
 
 ```css
 /* dark-theme.st.css */
-:import {
-    -st-from: './index.st.css';
-    -st-default: App;
-    -st-named: Button, DropDown;
-}
+@st-import App, [Button, DropDown] from "./index.st.css";
 
 @st-scope .root {
     App { border-color: darkgrey; }
@@ -53,17 +49,12 @@ In this theme implementation we are targeting three components and overriding th
 ```
 
 #### Extending a theme
+
 In this example, we are extending our previously created dark theme, with a specific override for the Gallery component.
 
 ```css
-:import {
-    -st-from: './gallery.st.css';
-    -st-default: Gallery;
-}
-:import {
-    -st-from: './dark.st.css';
-    -st-default: DarkTheme;
-}
+@st-import Gallery from "./gallery.st.css";
+@st-import DarkTheme from "./dark.st.css";
 
 @st-scope DarkTheme {
     DropDown {
@@ -74,14 +65,12 @@ In this example, we are extending our previously created dark theme, with a spec
 ```
 
 #### Theming with mixins
+
 In this file, we are creating pre-designed flavors that uses Stylable variables to determine their styling.
 
 ```css
 /* flavors.st.css */
-:import {
-    -st-from: './index.st.css';
-    -st-named: Button, UserForm;
-}
+@st-import [Button, UserForm] from "./index.st.css";
 
 :vars {
     background: white;
@@ -106,14 +95,8 @@ In this file, we are creating pre-designed flavors that uses Stylable variables 
 In this example, we use our existing flavors from above to customize our components look under the dark theme.
 
 ```css
-:import {
-    -st-from: './index.st.css';
-    -st-named: UserForm, Button;
-}
-:import {
-    -st-from: './flavors.st.css';
-    -st-named: button-flavor, userForm-flavor;
-}
+@st-import [UserForm, Button] from "./index.st.css";
+@st-import [button-flavor, userForm-flavor] from "./flavors.st.css";
 
 @st-scope .root {
     Button {

--- a/docs/references/tag-selectors.md
+++ b/docs/references/tag-selectors.md
@@ -60,10 +60,8 @@ When the value of a stylesheet is [imported](./imports.md) with a **capital firs
 
 ```css
 @namespace "Page";
-:import{
-    -st-from: "./toggle-button.st.css";
-    -st-default: ToggleButton;
-}
+@st-import ToggleButton from "./toggle-button.st.css";
+
 .root ToggleButton { background: green; }
 .sideBar:hover ToggleButton { background: red; }
 ```

--- a/docs/references/variables.md
+++ b/docs/references/variables.md
@@ -143,7 +143,7 @@ Stylable also offers a custom variable type, `stBorder`, that must be imported f
 `stBorder` accepts three arguments, `size`, `style` and `color` in that order. When using the type, you can either invoke the entire border definition (by not passing an additional argument), or specific parts of it, according to their key.
 
 ```css
-@st-import [stBorder] from "./custom.st.css";
+@st-import [stBorder] from "@stylable/custom-value";
 
 :vars {
     /* order of arguments: size style color */

--- a/docs/references/variables.md
+++ b/docs/references/variables.md
@@ -44,10 +44,8 @@ Any var defined in a stylesheet is exported as a named export and can be [import
 
 ```css
 @namespace "Example2";
-:import {
-    -st-from: "./example1.css"; /* Example1 stylesheet */
-    -st-named: color1, color2; /* import color1 and color2 variables */
-}
+@st-import [color1, color2] from "./example1.st.css";
+
 .root {
     border: 10px solid value(color1);
 }
@@ -78,10 +76,8 @@ You can set the value of a variable using another variable.
 
 ```css
 @namespace "Example3";
-:import {
-    -st-from: "./example1.css"; /* Example1 stylesheet */
-    -st-named: color1, color2;
-}
+@st-import [color1, color2] from "./example1.st.css";
+
 :vars {
     border1: 10px solid value(color1); /* use color1 in a complex value */
 }
@@ -147,10 +143,7 @@ Stylable also offers a custom variable type, `stBorder`, that must be imported f
 `stBorder` accepts three arguments, `size`, `style` and `color` in that order. When using the type, you can either invoke the entire border definition (by not passing an additional argument), or specific parts of it, according to their key.
 
 ```css
-:import {
-    -st-from: "@stylable/custom-value";
-    -st-named: stBorder;
-}
+@st-import [stBorder] from "./custom.st.css";
 
 :vars {
     /* order of arguments: size style color */

--- a/docs/unpublished/extending-through-js.md
+++ b/docs/unpublished/extending-through-js.md
@@ -55,11 +55,8 @@ Using these types enables the consumers of the plugin to receive code hinting an
 
 Values are strings exported via JavaScript modules they can be used inside a Stylable value() function.
 
-```css 
-:import {
-    -st-from: "../my-js-values.js";
-    -st-named: myValue;
-}
+```css
+@st-import [myValue] from "./my-js-values";
 
 .myClass {
     color: value(myValue);
@@ -82,12 +79,7 @@ Formatters are methods that manipulate parameters to produce a string that is re
 For example the following CSS code:
 
 ```css
-
-:import {
-    -st-from: "../my-formatter.js";
-    -st-named: lighten;
-    -st-default: frmt;
-}
+@st-import [lighten] from "./my-formatter";
 
 .myClass {
     color: lighten(30, #ff0000);
@@ -118,11 +110,7 @@ In many cases its useful to generate bigger chunks of css through js.
 Here's an example creating and using an expandOnHover mixin:
 
 ```css
-
-:import{
-    -st-from:"../my-mixins.js";
-    -st-named:expandOnHover;
-}
+@st-import [expandOnHover] from "../my-mixins.st.css";
 
 .myClass{
     -st-mixin:expandOnHover(200,2);


### PR DESCRIPTION
- remove legacy import examples (kept 1 in the imports docs to show legacy syntax)
- remove deprecated import variables override feature