### PR TITLE
docs: add v5 migration guide

### DIFF
--- a/docs/guides/migration-v5.md
+++ b/docs/guides/migration-v5.md
@@ -19,19 +19,22 @@ We plan on starting to map out the diagnostics in this site to help users unders
 
 ### Reducing public facing APIs
 
-In the past, Stylable exposed all of its functionalities as public facing APIs. Over time, this has proven difficult to maintain and develop further, and so We have decided to limit what Stylable exposes, and to segment its APIs under a few different namespaces.
+In the past, Stylable exposed all of its functionalities as public facing APIs. Over time, this has proven difficult to maintain and develop further, and so we have decided to limit what Stylable exposes, and to segment its APIs under a few different namespaces.
 
 In addition, most APIs have been refactored to match our new [programmatic API model](https://github.com/wix/stylable/wiki/Programmatic-API).
 
-#### Removed APIs
+#### API changes
 
 The following APIs have been changed:
 
 - `StylableMeta` renamed `rawAst` to `sourceAst` and `outputAst` to `targetAst`
+- The Stylable constructor now accepts options as an object (similar to `Stylable.create()` options)
 
 The following APIs have been removed:
 
+- The `Stylable.create()` method has been removed
 - `StylableMeta` removed `ast` field
+- `StylableTransformer` is no longer considered public API, there relevant functionality has been moved to `stylable.transform`, `stylable.transformSelector`, etc.
 - custom pseudo state parameter type `tag` has been removed - can be replaced by `-st-states: stateName(string)` (see [issue](https://github.com/wix/stylable/issues/1552#issuecomment-874559161))
 
 #### Missing APIs?
@@ -42,7 +45,7 @@ If we have removed an API that you have found useful, and provided no alternativ
 
 ### Default arguments changed
 
-The `@stylable/cli` `stc` command now has no output default output defined, previously this was set to emit `.cjs` files.
+The `@stylable/cli` `stc` command now has no default output defined, previously this was set to emit `.cjs` files.
 
 - If you were using the `stc` command without the `--cjs` flag, you will need to update your code to use the new default output
 - If were explictly setting the output to not emit `.cjs` files (e.g. `--no-cjs` or `--cjs=false`), you can now remove this parameter from your command

--- a/docs/guides/migration-v5.md
+++ b/docs/guides/migration-v5.md
@@ -18,6 +18,7 @@ In the past, Stylable exposed all of its functionalities as public facing APIs. 
 The following APIs have been removed, and an alternative was provided:
 
 - custom pseudo state parameter type `tag` has been removed - can be replaced by `-st-states: stateName(string)` (see [issue](https://github.com/wix/stylable/issues/1552#issuecomment-874559161))
+- the ability to pass `Stylable vars` as value to custom pseudo-state type has bee removed
 
 ### Missing APIs?
 

--- a/docs/guides/migration-v5.md
+++ b/docs/guides/migration-v5.md
@@ -17,7 +17,7 @@ In the past, Stylable exposed all of its functionalities as public facing APIs. 
 
 The following APIs have been removed, and an alternative was provided:
 
--
+- custom pseudo state parameter type `tag` has been removed - can be replaced by `-st-states: stateName(string)` (see [issue](https://github.com/wix/stylable/issues/1552#issuecomment-874559161))
 
 ### Missing APIs?
 

--- a/docs/guides/migration-v5.md
+++ b/docs/guides/migration-v5.md
@@ -18,7 +18,6 @@ In the past, Stylable exposed all of its functionalities as public facing APIs. 
 The following APIs have been removed, and an alternative was provided:
 
 - custom pseudo state parameter type `tag` has been removed - can be replaced by `-st-states: stateName(string)` (see [issue](https://github.com/wix/stylable/issues/1552#issuecomment-874559161))
-- the ability to pass `Stylable vars` as value to custom pseudo-state type has bee removed
 
 ### Missing APIs?
 

--- a/docs/guides/migration-v5.md
+++ b/docs/guides/migration-v5.md
@@ -1,0 +1,24 @@
+---
+id: migration-v5
+title: Migrating to Stylable v5
+---
+
+The purpose of this document is to help migrate projects using Stylable to `v5`.
+
+We have taken the opportunity of node dropping LTS support for `v12` and we have decided to include a number of additional breaking changes to the `v5` release. These changes are primarily to the programmatic API of Stylable and not to user facing features, syntax or integrations.
+
+You can find the plan for this major version [here](https://github.com/wix/stylable/issues/2410).
+
+## Reducing public facing APIs
+
+In the past, Stylable exposed all of its functionalities as public facing APIs. Over time, this has proven difficult to maintain and develop further, and so We have decided to limit what Stylable exposes, and to segment its APIs under a few different namespaces.
+
+### Removed APIs
+
+The following APIs have been removed, and an alternative was provided:
+
+-
+
+### Missing APIs?
+
+If we have removed an API that you have found useful, and provided no alternative, please let us know by opening an issue over at [GitHub](https://github.com/wix/stylable/issues/new/choose).

--- a/docs/guides/migration-v5.md
+++ b/docs/guides/migration-v5.md
@@ -9,16 +9,46 @@ We have taken the opportunity of node dropping LTS support for `v12` and we have
 
 You can find the plan for this major version [here](https://github.com/wix/stylable/issues/2410).
 
-## Reducing public facing APIs
+## `@stylable/core`
+
+### Diagnostics overhaul
+
+All diagnostics in `@stylable/core` had diagnostics code added, and were reviewed for consistency. Many diagnostics have had their severity increased to `error`.
+
+We plan on starting to map out the diagnostics in this site to help users understand what they are seeing, and why it happened.
+
+### Reducing public facing APIs
 
 In the past, Stylable exposed all of its functionalities as public facing APIs. Over time, this has proven difficult to maintain and develop further, and so We have decided to limit what Stylable exposes, and to segment its APIs under a few different namespaces.
 
-### Removed APIs
+In addition, most APIs have been refactored to match our new [programmatic API model](https://github.com/wix/stylable/wiki/Programmatic-API).
 
-The following APIs have been removed, and an alternative was provided:
+#### Removed APIs
 
+The following APIs have been changed:
+
+- `StylableMeta` renamed `rawAst` to `sourceAst` and `outputAst` to `targetAst`
+
+The following APIs have been removed:
+
+- `StylableMeta` removed `ast` field
 - custom pseudo state parameter type `tag` has been removed - can be replaced by `-st-states: stateName(string)` (see [issue](https://github.com/wix/stylable/issues/1552#issuecomment-874559161))
 
-### Missing APIs?
+#### Missing APIs?
 
 If we have removed an API that you have found useful, and provided no alternative, please let us know by opening an issue over at [GitHub](https://github.com/wix/stylable/issues/new/choose).
+
+## `@stylable/cli`
+
+### Default arguments changed
+
+The `@stylable/cli` `stc` command now has no output default output defined, previously this was set to emit `.cjs` files.
+
+- If you were using the `stc` command without the `--cjs` flag, you will need to update your code to use the new default output
+- If were explictly setting the output to not emit `.cjs` files (e.g. `--no-cjs` or `--cjs=false`), you can now remove this parameter from your command
+
+### Build index file and other outputs simultaneously
+
+The `@stylable/cli` `stc` command now supports building an indexFile and other outputs (`.js`, `.css`, `.st.css`, etc.) at once.
+
+- If you were previously running separate commands to build the index file and other outputs, you can now run a single command to build them all at once

--- a/docs/references/state-parameter-types.md
+++ b/docs/references/state-parameter-types.md
@@ -36,26 +36,6 @@ When defining a `default value`, you can use [variables](./variables.md) and [fo
 
 :::
 
-## Tag
-
-You can define a custom state with a **tags value** (seperated by whitespace), and then target it using a pseudo-class selector with a matching **tag argument**.
-
-```css
-.root {
-    /* define a custom state called "cart" */
-    -st-states: cart( tag )
-}
-
-.root:cart(shirt) {
-    /* targets an element that has a state with a value that
-    is a whitespace-separated list of tags, 
-    one of which is exactly the tag argument "shirt" */
-}
-```
-
-Setting the state **tag values** in the view `<span className={style(classes.root, {cart: "shirt"})}>` resolves to `<span className="style__root style---cart-5-shirt" />`.
-
-
 ## Enum
 
 You can define a custom state with possible **enum value** options, and then target one of the options using a pseudo-class selector with a matching **string argument**.

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -19,6 +19,7 @@ module.exports = {
     "guides/component-variants",
     "guides/ssr",
     "guides/migration-v3",
+    "guides/migration-v5",
   ],
   "Specification Reference": [
     "references/cheatsheet",


### PR DESCRIPTION
Migration guide for Stylable v5, will merge once released (and all content added).

To do:
- [x] - reference programmatic api in wiki
- [x] - add cli defaults section
- [x] - diagnostics refactor
- [x] - source and output ast on the meta, removed processed AST from meta
