### PR TITLE
fix: Next.js shared optimizer in example config

### DIFF
--- a/docs/getting-started/nextjs-integration.md
+++ b/docs/getting-started/nextjs-integration.md
@@ -19,6 +19,10 @@ const {
   applyWebpackConfigStylableExcludes,
 } = require("@stylable/webpack-plugin");
 
+/* single optimizer for NextJS multiple builds in order to sync client/server namespaces */
+const StylableOptimizer = require("@stylable/optimizer").StylableOptimizer;
+const stylableOptimizer = new StylableOptimizer();
+
 module.exports = {
   future: {
     webpack5: true,
@@ -35,6 +39,9 @@ module.exports = {
 
         /* output CSS to the correct location */
         filename: "static/css/stylable.[contenthash].css",
+
+        /* a shared optimizer instance */
+        optimizer: stylableOptimizer,
       })
     );
     return config;


### PR DESCRIPTION
This PR change the Next.js configuration example to pass a shared optimizer instance to builds in order to sync the target names.

This is because Next.js runs multiple webpack builds (client and server), and with the previous example config, when optimization is on (production mode), the optimized namespaces don't match between builds. 

