### PR TITLE
docs: build vars api reference re-write

### DIFF
--- a/docs/references/cheatsheet.mdx
+++ b/docs/references/cheatsheet.mdx
@@ -50,13 +50,13 @@ Syntax that is unique to Stylable or extended from CSS.
 
 ### Templating
 
-| Syntax                                                                                          | Explanations                                                                            |
-| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| <CodeBlock language="css" className="inline-code">:vars { x: red; y: blue; }</CodeBlock>        | Build time variables definition ([api](../references/variables.md#use-in-stylesheet))   |
-| <CodeBlock language="css" className="inline-code">prop: value(x);</CodeBlock>                   | Insert var value into declaration ([api](../references/variables.md#use-in-stylesheet)) |
-| <CodeBlock language="css" className="inline-code">prop: x(arg1, arg2);</CodeBlock>              | Computed value from custom formatter ([api](../references/formatters.md))               |
-| <CodeBlock language="css" className="inline-code">-st-mixin: x, y;</CodeBlock>                  | Apply multiple mixins to CSS ruleset ([api](../references/mixins.md))                   |
-| <CodeBlock language="css" className="inline-code">-st-mixin: x(param v1, param v2);</CodeBlock> | Apply mixins with override params ([api](../references/mixins.md))                      |
+| Syntax                                                                                          | Explanations                                                                   |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| <CodeBlock language="css" className="inline-code">:vars { x: red; y: blue; }</CodeBlock>        | Build time variables definition ([api](../references/variables.md#define))     |
+| <CodeBlock language="css" className="inline-code">prop: value(x);</CodeBlock>                   | Insert var value into declaration ([api](../references/variables.md#evaluate)) |
+| <CodeBlock language="css" className="inline-code">prop: x(arg1, arg2);</CodeBlock>              | Computed value from custom formatter ([api](../references/formatters.md))      |
+| <CodeBlock language="css" className="inline-code">-st-mixin: x, y;</CodeBlock>                  | Apply multiple mixins to CSS ruleset ([api](../references/mixins.md))          |
+| <CodeBlock language="css" className="inline-code">-st-mixin: x(param v1, param v2);</CodeBlock> | Apply mixins with override params ([api](../references/mixins.md))             |
 
 ### Other
 

--- a/docs/references/variables.md
+++ b/docs/references/variables.md
@@ -63,7 +63,7 @@ Variables can be composed into a declaration value.
 
 ### Array
 
-Use `st-array` to define a variable that holds a list of values that can be accessed by zero-based index.
+Use `st-array` to define a variable that holds a list of comma separated values that can be accessed by a zero-based index as the second argument to the `value()` function.
 
 ```css
 :vars {
@@ -79,7 +79,9 @@ Use `st-array` to define a variable that holds a list of values that can be acce
 
 ### Map
 
-Use `st-map` to define a variable that holds key/value pairs that can be accessed by key.
+Use `st-map` to define a variable that holds key/value pairs with a space as a delimiter between them, and a comma separating each pair.
+
+These values can then be accessed by providing the key as the second argument to the `value()` function.
 
 <!-- prettier-ignore-start -->
 ```css
@@ -97,10 +99,6 @@ Use `st-map` to define a variable that holds key/value pairs that can be accesse
 }
 ```
 <!-- prettier-ignore-end -->
-
-:::note map delimiters
-Each key/value pair uses a space as a delimiter between them, and a comma separates each pair.
-:::
 
 <!-- ### Nested -->
 <!-- ToDo: open this section once the referencing of array in map is fixed -->
@@ -157,8 +155,8 @@ stVars['dashed-name']; // "blue"
 ```
 <!-- prettier-ignore-end -->
 
-:::important only local export
-Only build variables that are defined by the stylesheet are exported to Javascript - **imported onces are not!**
+:::important local export only
+Only build variables that are defined by the stylesheet are exported to Javascript - **imported ones are not!**
 :::
 
 ## Custom variable


### PR DESCRIPTION
This PR re-writes the Stylable `build vars` api reference in favor of [Organize API references](https://github.com/wixplosives/stylable.io/issues/40) issue

- organize according to new page structure
- changed title to `Variables` from `Stylable variables` - similar to `Mixins` and `Formatters`.

There is a section about `complex data structures nesting` that I wrote, but kept commented until we solve the "referenced array in map bug"