### PR TITLE
Docs for css contains

### DIFF
--- a/docs/guides/handbook/namespace.md
+++ b/docs/guides/handbook/namespace.md
@@ -19,6 +19,7 @@ Symbols that Stylable namespaces:
 | Custom property | `--bgColor`        | `--NAMESPACE-bgColor`         |
 | Keyframes       | `@keyframes slide` | `@keyframes NAMESPACE__slide` |
 | Layer           | `@layer theme`     | `@layer NAMESPACE__theme`     |
+| Container       | `container: panel` | `container: NAEMSPACE__panel` |
 
 :::note
 Stylable does not namespace `id`, `custom-element`, `attribute`, or other symbols at the moment, but may add additional symbol namespacing support in the future.
@@ -59,6 +60,7 @@ We can avoid namespacing for all symbols (except classes) by using the `st-globa
 - `@property st-global(--bgColor)` - [read more](../../references/css-vars#disable-namespace)
 - `@keyframes st-global(slide)` - [read more](../../references/keyframes#disable-namespace)
 - `@layer st-global(theme)` - [read more](../../references/layer#disable-namespace)
+- `container: st-global(panel)` - [read more](../../references/contains#disable-namespace)
 
 Unlike the other symbols that are mapped from a local name to their global one, when we map a class using `-st-global`, we can define a global selector that will replace it.
 

--- a/docs/guides/handbook/namespace.md
+++ b/docs/guides/handbook/namespace.md
@@ -19,7 +19,7 @@ Symbols that Stylable namespaces:
 | Custom property | `--bgColor`        | `--NAMESPACE-bgColor`         |
 | Keyframes       | `@keyframes slide` | `@keyframes NAMESPACE__slide` |
 | Layer           | `@layer theme`     | `@layer NAMESPACE__theme`     |
-| Container       | `container: panel` | `container: NAEMSPACE__panel` |
+| Container       | `container: panel` | `container: NAMESPACE__panel` |
 
 :::note
 Stylable does not namespace `id`, `custom-element`, `attribute`, or other symbols at the moment, but may add additional symbol namespacing support in the future.

--- a/docs/guides/handbook/runtime.md
+++ b/docs/guides/handbook/runtime.md
@@ -18,7 +18,7 @@ For example, we need to:
 
 ## Mapped symbols
 
-The namespacing chapter covered the basics of namespacing in Stylable, and in it, we saw that in Stylable, **classes, custom-properties, keyframes, layers and containers** all receive namespacing to avoid conflicts.
+The namespacing chapter covered the basics of namespacing in Stylable, and in it, we saw that in Stylable, **classes, custom-properties, keyframes, layers, and containers** all receive namespacing to avoid conflicts.
 
 ### Import example
 

--- a/docs/guides/handbook/runtime.md
+++ b/docs/guides/handbook/runtime.md
@@ -18,17 +18,18 @@ For example, we need to:
 
 ## Mapped symbols
 
-The namespacing chapter covered the basics of namespacing in Stylable, and in it, we saw that in Stylable, **classes, custom-properties, keyframes, and layers** all receive namespacing to avoid conflicts.
+The namespacing chapter covered the basics of namespacing in Stylable, and in it, we saw that in Stylable, **classes, custom-properties, keyframes, layers and containers** all receive namespacing to avoid conflicts.
 
 ### Import example
 
 <!-- prettier-ignore-start -->
 ```js
 import {
-  classes,   // class mapping
-  vars,      // custom properties mapping
-  keyframes, // keyframes mapping
-  layers,    // layer mapping
+  classes,    // class mapping
+  vars,       // custom properties mapping
+  keyframes,  // keyframes mapping
+  layers,     // layer mapping
+  containers, // container mapping
 } from "./game.st.css";
 
 ```
@@ -40,6 +41,7 @@ import {
 | `vars`          | Custom property | `--player1Color`   | `--NS-player1Color`    |
 | `keyframes`     | Keyframes       | `@keyframes slide` | `@keyframes NS__slide` |
 | `layers`        | Layer           | `@layer theme`     | `@layer NS__theme`     |
+| `containers`    | Container       | `container: panel` | `container: NS__panel` |
 
 <!-- prettier-ignore-end -->
 

--- a/docs/references/cheatsheet.mdx
+++ b/docs/references/cheatsheet.mdx
@@ -39,7 +39,8 @@ Syntax that is unique to Stylable or extended from CSS.
 | <CodeBlock language="css" className="inline-code">@st-import X, [y, z] from './y.st.css';</CodeBlock>           | Import default & named ([api](../references/imports.md#named-import))      |
 | <CodeBlock language="css" className="inline-code">@st-import [x as local-x] from './y.st.css';</CodeBlock>      | Local alias for named import ([api](../references/imports.md#local-alias)) |
 | <CodeBlock language="css" className="inline-code">@st-import [keyframes(x1, x2)] from './y.st.css';</CodeBlock> | Import keyframes ([api](../references/keyframes#import-and-export))        |
-| <CodeBlock language="css" className="inline-code">@st-import [layers(x1, x2)] from './y.st.css';</CodeBlock>    | Import layers ([api](../references/layer#import-and-export))               |
+| <CodeBlock language="css" className="inline-code">@st-import [layer(x1, x2)] from './y.st.css';</CodeBlock>     | Import layers ([api](../references/layer#import-and-export))               |
+| <CodeBlock language="css" className="inline-code">@st-import [container(x1, x2)] from './y.st.css';</CodeBlock> | Import containers ([api](../references/contains#import-and-export))            |
 
 ### Class extensions
 

--- a/docs/references/contains.md
+++ b/docs/references/contains.md
@@ -1,0 +1,134 @@
+---
+id: contains
+title: Containers
+---
+
+CSS container queries are used to target and style an element depending on the conditions of a container it is nested within.
+
+This page goes over how Stylable handles the `container-name` declaration and the `@container` at-rule, for more details about the language feature itself, checkout the following resources:
+
+- [MDN CSS container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries)
+- [CSS contains spec](https://drafts.csswg.org/css-contain-3)
+
+## Syntax
+
+**Container definition**
+
+```css
+.panel {
+  /* longhand */
+  container-name: panel;
+
+  /* shorthand */
+  container-name: panel / inline-size;
+
+  /* longhand with multiple names */
+  container-name: panel side;
+}
+```
+
+**Usage**
+
+<!-- prettier-ignore-start -->
+```css
+@container panel (width <= 250px) {
+  /* style nested rules */
+}
+```
+<!-- prettier-ignore-end -->
+
+## Import and Export
+
+An exported container can be imported into another stylesheet with the [@st-import](./imports.md) atrule.
+
+**Style nested container rules**
+
+<!-- prettier-ignore-start -->
+```css
+/* get 'panel' container definition from another stylesheet */
+@st-import [container(panel)] from './x.st.css';
+
+@container panel (width <= 150px) {
+    /* nested container rules */
+}
+```
+<!-- prettier-ignore-end -->
+
+**More import examples**
+
+```css
+/* map 'panel' container to local name 'x-panel' */
+@st-import [container(panel as x-panel)] from './x.st.css';
+
+/* import multiple containers */
+@st-import [container(panel, header)] from './x.st.css';
+```
+
+## Runtime
+
+A Container definition can be accessed to generate dynamic styles using the containers mapping on the Stylable runtime stylesheet:
+
+```js
+import { containers } from './sheet.st.css';
+
+// map to target namespaced container
+containers.panel;
+```
+
+## Namespace
+
+Stylable automatically namespaces any container name according to the stylesheet it is defined in:
+
+<!-- prettier-ignore-start -->
+```css
+.x {
+  container: panel;
+}
+
+@container panel (width > 100px) {}
+
+/* OUTPUT */
+.x {
+  container: NAMESPACE__panel;
+}
+
+@container NAMESPACE__panel (width > 100px) {}
+```
+<!-- prettier-ignore-end -->
+
+### Disable namespace
+
+In some cases the default namespace behavior is unwanted. In such cases, `st-global` can be used to mark a container definition as global:
+
+<!-- prettier-ignore-start -->
+```css
+.x {
+  container: st-global(panel);
+}
+
+@container panel (width > 100px) {}
+
+/* OUTPUT */
+.x {
+  container: panel;
+}
+
+@container panel (width > 100px) {}
+```
+<!-- prettier-ignore-end -->
+
+In case a container is not defined within a stylable stylesheet and is just used in a container query, the `st-global` function can be used directly in the `@container` at-rule.
+
+<!-- prettier-ignore-start -->
+```css
+@container st-global(panel) (width > 100px) {}
+
+/* OUTPUT */
+
+@container panel (width > 100px) {}
+```
+<!-- prettier-ignore-end -->
+
+:::info Referencing a global container name
+When `st-global` is used in the `@container` at-rule it doesn't register a symbol and is not available for import in another Stylesheet or in the JavaScript runtime.
+:::

--- a/docs/references/contains.md
+++ b/docs/references/contains.md
@@ -27,6 +27,10 @@ This page goes over how Stylable handles the `container-name` declaration and th
 }
 ```
 
+:::note soft definition
+A container name symbol is defined using the `container/container-name` declaration only when not explicitly defined by an import or a [global `@container` definition](#disable-namespace).
+:::
+
 **Usage**
 
 <!-- prettier-ignore-start -->
@@ -98,7 +102,7 @@ Stylable automatically namespaces any container name according to the stylesheet
 
 ### Disable namespace
 
-In some cases the default namespace behavior is unwanted. In such cases, `st-global` can be used to mark a container definition as global:
+In some cases the default namespace behavior is unwanted. In such cases, `st-global` can be used to set a container name as global:
 
 <!-- prettier-ignore-start -->
 ```css
@@ -106,7 +110,7 @@ In some cases the default namespace behavior is unwanted. In such cases, `st-glo
   container: st-global(panel);
 }
 
-@container panel (width > 100px) {}
+@container st-global(panel) (width > 100px) {}
 
 /* OUTPUT */
 .x {
@@ -117,18 +121,28 @@ In some cases the default namespace behavior is unwanted. In such cases, `st-glo
 ```
 <!-- prettier-ignore-end -->
 
-In case a container is not defined within a stylable stylesheet and is just used in a container query, the `st-global` function can be used directly in the `@container` at-rule.
+::note global without symbol deinition
+Setting `st-global` around the container name in either the declaration or container query only references a global container name, without creating a symbol that can later be imported or referenced.
+::
+
+To register a global container name symbol, that can be imported and referenced by other stylesheets, use the `@container` at-rule with no body or query:
 
 <!-- prettier-ignore-start -->
 ```css
-@container st-global(panel) (width > 100px) {}
+/* global panel container name definition */
+@container st-global(panel);
+
+.x {
+  container: panel;
+}
+@container panel (width > 100px) {}
+
 
 /* OUTPUT */
 
+.x {
+  container: panel;
+}
 @container panel (width > 100px) {}
 ```
 <!-- prettier-ignore-end -->
-
-:::info Referencing a global container name
-When `st-global` is used in the `@container` at-rule it doesn't register a symbol and is not available for import in another Stylesheet or in the JavaScript runtime.
-:::

--- a/docs/references/contains.md
+++ b/docs/references/contains.md
@@ -39,7 +39,7 @@ This page goes over how Stylable handles the `container-name` declaration and th
 
 ## Import and Export
 
-An exported container can be imported into another stylesheet with the [@st-import](./imports.md) atrule.
+An exported container can be imported into another stylesheet with the [@st-import](./imports.md) at-rule.
 
 **Style nested container rules**
 

--- a/docs/references/contains.md
+++ b/docs/references/contains.md
@@ -5,7 +5,7 @@ title: Containers
 
 CSS container queries are used to target and style an element depending on the conditions of a container it is nested within.
 
-This page goes over how Stylable handles the `container-name` declaration and the `@container` at-rule, for more details about the language feature itself, checkout the following resources:
+This page goes over how Stylable handles the `container-name` declaration and the `@container` at-rule, for more details about the language feature itself, check out the following resources:
 
 - [MDN CSS container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries)
 - [CSS contains spec](https://drafts.csswg.org/css-contain-3)

--- a/docs/references/imports.md
+++ b/docs/references/imports.md
@@ -65,6 +65,7 @@ When importing from a stylesheet, the [root](./root.md#default-export) class is 
 /* define symbols */
 .part {
   --customProp: yellow;
+  container-name: part;
 }
 @keyframes anim {}
 @layer comps, theme;
@@ -88,20 +89,22 @@ When importing a **default** value from a stylable stylesheet, you should use a 
 
 ### Named type assertion
 
-To import keyframes or layers from another stylesheet, a special [keyframes()](./keyframes.md#import-and-export) or [layer()](./layer#import-and-export) assertion is required.
+To import keyframes, layers or containers from another stylesheet, a special [keyframes()](./keyframes.md#import-and-export), [layer()](./layer#import-and-export), or [container()](./contains#import-and-export) assertion is required.
 
 <!-- prettier-ignore-start -->
 ```css title="entry.st.css"
 /* import keyframe and layer */
 @st-import [
   keyframes(anim),
-  layer(theme)
+  layer(theme),
+  container(panel)
 ] from './origin.st.css';
 
 /* multiple */
 @st-import [
   keyframes(anim1, anim2), 
-  layer(comps, theme)
+  layer(comps, theme),
+  container(panel, header)
 ] from './origin.st.css';
 ```
 <!-- prettier-ignore-end -->

--- a/docs/references/runtime.md
+++ b/docs/references/runtime.md
@@ -5,7 +5,6 @@ title: Runtime
 
 Imported Stylable stylesheets in JavaScript contain minimal runtime code to help define the structure and state of the component.
 
-
 <!-- prettier-ignore-start -->
 ```js
 /* index.jsx - stylesheet runtime api */
@@ -17,6 +16,7 @@ import {
     cssStates, // utility function for setting stylable states
     keyframes, // keyframes mapping
     layers     // layer mapping
+    containers,// container mapping
 } from "style.st.css";
 ```
 <!-- prettier-ignore-end -->
@@ -27,7 +27,7 @@ Any namespaced symbols, defined in the stylesheet, are exposed on maps from thei
 
 <!-- prettier-ignore-start -->
 ```js
-import { classes, vars, keyframes, layers } from 'style.st.css';
+import { classes, vars, keyframes, layers, containers } from 'style.st.css';
 
 // class
 classes.root;            // "style__root"
@@ -43,6 +43,9 @@ keyframes.slide          // "style__slide"
 
 // layers
 layers.theme             // "style__theme"
+
+// containers
+containers.panel         // "style__panel"
 ```
 <!-- prettier-ignore-end -->
 
@@ -55,6 +58,7 @@ The [root class](../references/root.md) is available even when it is not explici
 ## Build vars
 
 Local stylesheet [build vars](./variables.md) are exported with their set value.
+
 <!-- prettier-ignore-start -->
 ```css
 :vars {
@@ -79,11 +83,12 @@ A utility function for concatenating [classes](./class-selectors.md) and activat
 - multiple classes can be added with additional arguments
 
 **Multiple classes**
+
 ```js
 import { st, classes } from 'style.st.css';
 
 // namespaced part class + additional class
-st(classes.part, 'additional');  // "style__part additional"
+st(classes.part, 'additional'); // "style__part additional"
 
 // namespaced part class + multiple classes
 st(classes.part, 'a', 'b', 'c'); // "style__part a b c"
@@ -93,25 +98,27 @@ st(classes.part, 'a', undefined, 'c'); // "style__part a c"
 ```
 
 **State activation**
+
 ```js
 import { st, classes } from 'style.st.css';
 
 // namespaced a + isOn boolean state
-st(classes.a, {isOn: true}); // "style__a style--isOn"
+st(classes.a, { isOn: true }); // "style__a style--isOn"
 
 // namespaced a + multiple states
-st(classes.a, {x: true, y: false}); // "style__a style--x"
+st(classes.a, { x: true, y: false }); // "style__a style--x"
 
 // namespaced a + parameter
-st(classes.a, {rank: 'first'}); // "style__a style--rank-5-first"
+st(classes.a, { rank: 'first' }); // "style__a style--rank-5-first"
 ```
 
 **State activation + additional classes**
+
 ```js
 import { st, classes } from 'style.st.css';
 
 // namespaced a + isOn state + x class
-st(classes.a, {isOn: true}, 'x'); // "style__a style--isOn x"
+st(classes.a, { isOn: true }, 'x'); // "style__a style--isOn x"
 ```
 
 ## Custom state mapping

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -75,6 +75,7 @@ module.exports = {
             collapsed: false,
             items: [
                 'references/class-selectors',
+                'references/contains',
                 'references/css-vars',
                 'references/keyframes',
                 'references/layer',


### PR DESCRIPTION
This PR adds the documentation for supporting [css contain spec](https://drafts.csswg.org/css-contain-3/)